### PR TITLE
feat: Include draft posts in PR preview (Netlify) builds

### DIFF
--- a/config/pr-preview/config.toml
+++ b/config/pr-preview/config.toml
@@ -1,0 +1,2 @@
+# PR preview 환경: draft 포스트도 빌드에 포함
+buildDrafts = true


### PR DESCRIPTION
## Summary

- `config/pr-preview/config.toml` 신규 추가: `buildDrafts = true` 설정
- PR 미리보기 빌드(Netlify)에서 `draft: true` 포스트가 렌더링에 포함됨

## Why

Hugo는 기본적으로 `draft: true` 포스트를 빌드에서 제외한다. PR 단계에서 초안을 Netlify 미리보기 URL로 직접 확인하려면 draft 포함 빌드가 필요하다.

## How

`config/pr-preview/` 환경 디렉터리에 `config.toml`을 추가하는 것만으로 충분하다.  
GitHub Actions (`pr-preview.yml`)와 Netlify 직접 빌드(`netlify.toml`) 모두 이미 `--environment pr-preview`를 사용하고 있어, 두 경로 모두 이 파일 하나로 커버된다. 기존 `netlify.toml`이나 `pr-preview.yml` 수정 없음.

## Test plan

- [ ] PR을 열어 Netlify 미리보기 빌드가 완료되면, `draft: true` 포스트가 미리보기 URL에서 접근 가능한지 확인
- [ ] 프로덕션 빌드(`main` 브랜치)에는 draft가 포함되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)